### PR TITLE
PackageResourceListingStrategy and BindingStrategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 build
 gradle.properties
 
+# maven stuff
+
+target
+
 # Eclipse IDE stuff
 
 .project

--- a/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/bindings/BindingStrategy.java
+++ b/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/bindings/BindingStrategy.java
@@ -1,0 +1,13 @@
+package ch.obermuhlner.scriptengine.java.bindings;
+
+import java.util.Map;
+
+/**
+ * The strategy used to set/get the Bindings around invoke
+ */
+public interface BindingStrategy {
+	
+	void associateBindings(Class<?> compiledClass, Object compiledInstance, Map<String, Object> mergedBindings);
+	
+	Map<String, Object> retrieveBindings(Class<?> compiledClass, Object compiledInstance);
+}

--- a/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/packagelisting/PackageResourceListingStrategy.java
+++ b/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/packagelisting/PackageResourceListingStrategy.java
@@ -1,0 +1,11 @@
+package ch.obermuhlner.scriptengine.java.packagelisting;
+
+import java.util.Collection;
+
+/**
+ * The strategy used to list the Java classes in a package
+ */
+public interface PackageResourceListingStrategy {
+	
+	Collection<String> listResources(String packageName);
+}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ch.obermuhlner</groupId>
   <artifactId>java-scriptengine</artifactId>
-  <version>1.0.1</version>
+  <version>2.1.0</version>
   <name>Java ScriptEngine</name>
   <description>Java script engine for Java as a scripting language.</description>
   <url>https://github.com/eobermuhlner/java-scriptengine</url>
@@ -26,6 +26,14 @@
     <developerConnection>scm:ssh://github.com:eobermuhlner/java-scriptengine.git</developerConnection>
     <url>https://github.com/eobermuhlner/java-scriptengine/</url>
   </scm>
+  
+
+	<properties>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>  
+  
   <dependencies>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
These are changes to use java-scriptengine for openHAB rules.
* MemoryFileManager.list() can use a strategy to list classes in classpath packages, for OSGI the strategy would use bundleWiring.listResources
* added BindingStrategy interface, so bindings could be set in bulk and one does not need to have a variable for each key
* can be built with Maven if ch.obermuhlner.scriptengine.java/src is symlinked to src

The changes are used in
https://github.com/weberjn/org.openhab.automation.javarules/tree/externalize_java-scriptengine/src/main/java/org/openhab/automation/javarules/internal

See https://github.com/eobermuhlner/java-scriptengine/issues/12