### PR TITLE
New CompilationStrategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ try {
 }
 ```
 
-### Set `CompilationStrategy` in `JavaCompiledScript`
+### Set `CompilationStrategy` in `JavaScriptEngine`
 
 You can specify the strategy to choose which files to compile alongside your script.
 

--- a/README.md
+++ b/README.md
@@ -438,6 +438,23 @@ try {
 }
 ```
 
+### Set `CompilationStrategy` in `JavaCompiledScript`
+
+You can specify the strategy to choose which files to compile alongside your script.
+
+```java
+public interface CompilationStrategy {
+
+    List<JavaFileObject> getJavaFileObjectsToCompile(String simpleClassName, String currentSource);
+
+}
+```
+
+The default implementation `DefaultCompilationStrategy` compiles only the current script.
+
+An `IncrementalCompilationStrategy` is available and keeps the previous source files used in the same `JavaScriptEngine`.
+
+
 ### Set `Isolation` in `JavaScriptEngine`
 
 You can specfy the `Isolation` level of the script.

--- a/ch.obermuhlner.scriptengine.example/src/main/java/ch/obermuhlner/scriptengine/example/ScriptEngineExample.java
+++ b/ch.obermuhlner.scriptengine.example/src/main/java/ch/obermuhlner/scriptengine/example/ScriptEngineExample.java
@@ -3,6 +3,7 @@ package ch.obermuhlner.scriptengine.example;
 import ch.obermuhlner.scriptengine.java.Isolation;
 import ch.obermuhlner.scriptengine.java.JavaCompiledScript;
 import ch.obermuhlner.scriptengine.java.JavaScriptEngine;
+import ch.obermuhlner.scriptengine.java.compilation.IncrementalCompilationStrategy;
 import ch.obermuhlner.scriptengine.java.constructor.DefaultConstructorStrategy;
 import ch.obermuhlner.scriptengine.java.execution.MethodExecutionStrategy;
 
@@ -21,6 +22,7 @@ public class ScriptEngineExample {
         runConstructorStrategyMatchingArgumentsExample();
         runMethodExecutionStrategyFactoryMatchingArgumentsExample();
         runCompiledMethodExecutionStrategyMatchingArgumentsExample();
+        runIncrementalCompilationExample();
         runIsolationCallerClassLoaderClassesExample();
         runIsolationIsolatedClassesExample();
         runDangerousCode1Example();
@@ -246,6 +248,36 @@ public class ScriptEngineExample {
             e.printStackTrace();
         }
     }
+    
+    private static void runIncrementalCompilationExample() {
+        try {
+            ScriptEngineManager manager = new ScriptEngineManager();
+            ScriptEngine engine = manager.getEngineByName("java");
+            JavaScriptEngine javaScriptEngine = (JavaScriptEngine) engine;
+            javaScriptEngine.setCompilationSrategy(new IncrementalCompilationStrategy());
+            Compilable compiler = (Compilable) engine;
+
+            CompiledScript compiledLibrary = compiler.compile("" +
+                    "public class MyLibrary {" +
+                    "   public static String getMessage() {" +
+                    "       return \"Hello World #\";" +
+                    "   } " +
+                    "}");
+
+            CompiledScript compiledScript = compiler.compile("" +
+                    "public class MyScript {" +
+                    "   public String exec() {" +
+                    "       return MyLibrary.getMessage();" +
+                    "   } " +
+                    "}");
+
+            Object result2 = compiledScript.eval();
+            System.out.println("Result of calling library: " + result2);
+        } catch (ScriptException e) {
+            e.printStackTrace();
+        }
+    }
+    
 
     private static void runIsolationCallerClassLoaderClassesExample() {
         try {

--- a/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/MemoryFileManager.java
+++ b/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/MemoryFileManager.java
@@ -46,7 +46,7 @@ public class MemoryFileManager extends ForwardingJavaFileManager<JavaFileManager
         return mapNameToClasses.values();
     }
 
-    public JavaFileObject createSourceFileObject(Object origin, String name, String code) {
+    public static JavaFileObject createSourceFileObject(Object origin, String name, String code) {
         return new MemoryJavaFileObject(origin, name, JavaFileObject.Kind.SOURCE, code);
     }
 

--- a/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/compilation/CompilationStrategy.java
+++ b/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/compilation/CompilationStrategy.java
@@ -1,0 +1,30 @@
+package ch.obermuhlner.scriptengine.java.compilation;
+
+import java.util.List;
+
+import javax.tools.JavaFileObject;
+
+/**
+ * This strategy is used to decide what to compile
+ */
+public interface CompilationStrategy {
+
+    /**
+     * Generate a list of JavaFileObject to compile
+     *
+     * @param simpleClassName the class name of the script
+     * @param currentSource   The current source script we want to execute
+     * @return
+     */
+    List<JavaFileObject> getJavaFileObjectsToCompile(String simpleClassName, String currentSource);
+
+    /**
+     * As the script is compiled, this is an opportunity to see if we still want to
+     * keep it.
+     *
+     * @param clazz
+     */
+    default void compilationResult(Class<?> clazz) {
+    }
+
+}

--- a/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/compilation/DefaultCompilationStrategy.java
+++ b/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/compilation/DefaultCompilationStrategy.java
@@ -1,0 +1,18 @@
+package ch.obermuhlner.scriptengine.java.compilation;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.tools.JavaFileObject;
+
+import ch.obermuhlner.scriptengine.java.MemoryFileManager;
+
+public class DefaultCompilationStrategy implements CompilationStrategy {
+
+    @Override
+    public List<JavaFileObject> getJavaFileObjectsToCompile(String simpleClassName, String currentSource) {
+	return Collections
+		.singletonList(MemoryFileManager.createSourceFileObject(null, simpleClassName, currentSource));
+    }
+
+}

--- a/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/compilation/IncrementalCompilationStrategy.java
+++ b/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/compilation/IncrementalCompilationStrategy.java
@@ -1,0 +1,34 @@
+package ch.obermuhlner.scriptengine.java.compilation;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
+
+import javax.tools.JavaFileObject;
+
+import ch.obermuhlner.scriptengine.java.MemoryFileManager;
+
+public class IncrementalCompilationStrategy implements CompilationStrategy {
+
+    Map<String, JavaFileObject> previousFileObject = new HashMap<>();
+    
+    JavaFileObject currentJavaFileObject; 
+
+    @Override
+    public List<JavaFileObject> getJavaFileObjectsToCompile(String simpleClassName, String currentSource) {
+	currentJavaFileObject = MemoryFileManager.createSourceFileObject(null, simpleClassName,
+		currentSource);
+	Stream<JavaFileObject> previousFileObjects = previousFileObject.entrySet().stream()
+		.filter(entry -> !entry.getKey().equals(simpleClassName)) // do no keep the old file
+		.map(Entry::getValue);
+	return Stream.concat(previousFileObjects, Stream.of(currentJavaFileObject)).toList();
+    }
+
+    @Override
+    public void compilationResult(Class<?> clazz) {	
+	previousFileObject.put(clazz.getSimpleName(), currentJavaFileObject);
+    }
+
+}


### PR DESCRIPTION
Hello,

First of all, thanks for your work.

As you already know, thanks to @weberjn who did a great job, your JSR223 implementation is used in openHAB (alongside other languages).

Enabling a kind of "user library" in each of these scripting languages is a frequent request on the community forum.

So this PR proposes to add a compilation strategy, to choose what to compile alongside the main script.
I added an "Incremental" implementation as an example, that keeps previously compiled script in memory.

I choose to not meddle with the class loader mechanism and go for the "recompile all" route, as class loader are not made to recompile same class over and over (and it happens frequently in our use case).

Hope this will be of some value.