### PR TITLE
Adding an interceptor strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,21 @@ The default implementation `DefaultCompilationStrategy` compiles only the curren
 An `IncrementalCompilationStrategy` is available and keeps the previous source files used in the same `JavaScriptEngine`.
 
 
+### Set `ScriptInterceptorStrategy` in `JavaScriptEngine`
+
+You can intercept the code just before the compilation to modify it.
+
+```java
+public interface ScriptInterceptorStrategy {
+
+    public String intercept(String script);
+    
+}
+```
+
+The default implementation `NoInterceptorStrategy` does not modify the script.
+
+
 ### Set `Isolation` in `JavaScriptEngine`
 
 You can specfy the `Isolation` level of the script.

--- a/ch.obermuhlner.scriptengine.example/src/main/java/ch/obermuhlner/scriptengine/example/ScriptEngineExample.java
+++ b/ch.obermuhlner.scriptengine.example/src/main/java/ch/obermuhlner/scriptengine/example/ScriptEngineExample.java
@@ -254,7 +254,7 @@ public class ScriptEngineExample {
             ScriptEngineManager manager = new ScriptEngineManager();
             ScriptEngine engine = manager.getEngineByName("java");
             JavaScriptEngine javaScriptEngine = (JavaScriptEngine) engine;
-            javaScriptEngine.setCompilationSrategy(new IncrementalCompilationStrategy());
+            javaScriptEngine.setCompilationStrategy(new IncrementalCompilationStrategy());
             Compilable compiler = (Compilable) engine;
 
             CompiledScript compiledLibrary = compiler.compile("" +

--- a/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/JavaScriptEngine.java
+++ b/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/JavaScriptEngine.java
@@ -3,6 +3,8 @@ package ch.obermuhlner.scriptengine.java;
 import ch.obermuhlner.scriptengine.java.bindings.BindingStrategy;
 import ch.obermuhlner.scriptengine.java.compilation.CompilationStrategy;
 import ch.obermuhlner.scriptengine.java.compilation.DefaultCompilationStrategy;
+import ch.obermuhlner.scriptengine.java.compilation.NoInterceptorStrategy;
+import ch.obermuhlner.scriptengine.java.compilation.ScriptInterceptorStrategy;
 import ch.obermuhlner.scriptengine.java.constructor.ConstructorStrategy;
 import ch.obermuhlner.scriptengine.java.constructor.DefaultConstructorStrategy;
 import ch.obermuhlner.scriptengine.java.execution.DefaultExecutionStrategy;
@@ -33,6 +35,7 @@ public class JavaScriptEngine implements ScriptEngine, Compilable {
     private PackageResourceListingStrategy packageResourceListingStrategy = null;
     private BindingStrategy bindingStrategy = null;
     private CompilationStrategy compilationStrategy = new DefaultCompilationStrategy();
+    private ScriptInterceptorStrategy scriptInterceptorStrategy = new NoInterceptorStrategy();
 
     private ScriptContext context = new SimpleScriptContext();
 
@@ -57,15 +60,19 @@ public class JavaScriptEngine implements ScriptEngine, Compilable {
     }
 
     public void setPackageResourceListingStrategy(PackageResourceListingStrategy packageResourceListingStrategy) {
-    	this.packageResourceListingStrategy = packageResourceListingStrategy;
+        this.packageResourceListingStrategy = packageResourceListingStrategy;
     }
 
     public void setBindingStrategy(BindingStrategy bindingStrategy) {
-    	this.bindingStrategy = bindingStrategy;
+        this.bindingStrategy = bindingStrategy;
     }
 
-    public void setCompilationSrategy(CompilationStrategy compilationStrategy) {
+    public void setCompilationStrategy(CompilationStrategy compilationStrategy) {
         this.compilationStrategy = compilationStrategy;
+    }
+
+    public void setScriptInterceptorStrategy(ScriptInterceptorStrategy scriptInterceptorStrategy) {
+        this.scriptInterceptorStrategy = scriptInterceptorStrategy;
     }
 
     /**
@@ -178,7 +185,10 @@ public class JavaScriptEngine implements ScriptEngine, Compilable {
     }
 
     @Override
-    public JavaCompiledScript compile(String script) throws ScriptException {
+    public JavaCompiledScript compile(String originalScript) throws ScriptException {
+
+        String script = scriptInterceptorStrategy.intercept(originalScript);
+
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
         StandardJavaFileManager standardFileManager = compiler.getStandardFileManager(diagnostics, null, null);

--- a/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/compilation/NoInterceptorStrategy.java
+++ b/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/compilation/NoInterceptorStrategy.java
@@ -1,0 +1,10 @@
+package ch.obermuhlner.scriptengine.java.compilation;
+
+public class NoInterceptorStrategy implements ScriptInterceptorStrategy {
+
+    @Override
+    public String intercept(String actualScript) {
+	return actualScript;
+    }
+
+}

--- a/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/compilation/ScriptInterceptorStrategy.java
+++ b/ch.obermuhlner.scriptengine.java/src/main/java/ch/obermuhlner/scriptengine/java/compilation/ScriptInterceptorStrategy.java
@@ -1,0 +1,10 @@
+package ch.obermuhlner.scriptengine.java.compilation;
+
+/**
+ * This strategy allows to modify a script before compiling it.
+ */
+public interface ScriptInterceptorStrategy {
+
+    public String intercept(String script);
+    
+}


### PR DESCRIPTION
Allows last moment modification to scripts.

In openHAB architecture, when designing a JSR223 addon, we don't have access to the script before its compilation, we only provide an engine to the core. In order to achieve some last moment modifications to the script, could you please consider adding an interceptor strategy such as this one ?

Thanks,